### PR TITLE
Use advertisevo for GlueCEAccessControlBaseRule generation

### DIFF
--- a/src/services/a-rex/infoproviders/ARC0ClusterInfo.pm
+++ b/src/services/a-rex/infoproviders/ARC0ClusterInfo.pm
@@ -291,6 +291,13 @@ sub collect($) {
             # merge cluster wide and queue-specific options
             my $sconfig = { %{$config->{service}}, %{$config->{shares}{$share}} };
 
+            my @queue_advertisedvos = ();
+            if ($sconfig->{AdvertisedVO}) {
+                @queue_advertisedvos = @{$sconfig->{AdvertisedVO}};
+                # add VO: suffix to each advertised VO
+                @queue_advertisedvos = map { "VO:".$_ } @queue_advertisedvos;
+            }
+
             $sconfig->{ExecutionEnvironmentName} ||= [];
             my @nxenvs = @{$sconfig->{ExecutionEnvironmentName}};
 
@@ -373,6 +380,8 @@ sub collect($) {
             } elsif ( $qinfo->{totalcpus} ) {
                 $q->{totalcpus} = $qinfo->{totalcpus};
             }	
+
+            $q->{acl} = [ @queue_advertisedvos ] if @queue_advertisedvos;
 
             keys %$gmjobs_info; # reset iterator of each()
 

--- a/src/services/a-rex/infoproviders/NGldifPrinter.pm
+++ b/src/services/a-rex/infoproviders/NGldifPrinter.pm
@@ -106,7 +106,8 @@ sub queueAttributes {
                                                      maxwalltime
                                                      minwalltime
                                                      defaultwalltime
-                                                     maxtotalcputime ));
+                                                     maxtotalcputime
+                                                     acl ));
 }
 
 sub jobAttributes {

--- a/src/services/a-rex/infoproviders/glue-generator.pl
+++ b/src/services/a-rex/infoproviders/glue-generator.pl
@@ -87,6 +87,7 @@ my %queue_attributes=(
     'nordugrid-queue-gridqueued' => '',
     'nordugrid-queue-localqueued' => '',
     'nordugrid-queue-prelrmsqueued' => '',
+    'nordugrid-queue-acl' => '',
     );
 
 #all these values will be checked if they are numeric only:
@@ -506,7 +507,11 @@ GlueCEPolicyMaxTotalJobs: $queue_attributes{'nordugrid-queue-maxqueuable'}
 GlueCEPolicyMaxWallClockTime: $queue_attributes{'nordugrid-queue-maxcputime'}
 GlueCEPolicyPriority: 1
 GlueCEPolicyAssignedJobSlots: $AssignedSlots\n";
-            foreach (@vos){
+            if ($queue_attributes{'nordugrid-queue-acl'} eq "DEFALUT") {
+                $queue_attributes{'nordugrid-queue-acl'}="VO:ops";
+            }
+            my @qvos= split / /, $queue_attributes{'nordugrid-queue-acl'};
+            foreach (@qvos){
                 chomp;
                 print "GlueCEAccessControlBaseRule: $_\n";
             }

--- a/src/services/a-rex/infoproviders/schema/nordugrid.schema
+++ b/src/services/a-rex/infoproviders/schema/nordugrid.schema
@@ -747,6 +747,14 @@ attributetype ( 1.3.6.1.4.1.11604.2.1.3.27
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
 
+attributetype ( 1.3.6.1.4.1.11604.2.1.3.28
+    NAME 'nordugrid-queue-acl'
+    DESC 'Cluster authorization information'
+    EQUALITY caseExactMatch
+    ORDERING caseExactOrderingMatch
+    SUBSTR caseExactSubstringsMatch
+    SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
+
 objectclass ( 1.3.6.1.4.1.11604.2.1.3
     NAME 'nordugrid-queue'
     DESC 'An LRMS queue'
@@ -765,7 +773,7 @@ objectclass ( 1.3.6.1.4.1.11604.2.1.3
 	   nordugrid-queue-homogeneity $ nordugrid-queue-prelrmsqueued $
 	   nordugrid-queue-localqueued $ nordugrid-queue-maxwalltime $
 	   nordugrid-queue-minwalltime $ nordugrid-queue-defaultwalltime $
-	   nordugrid-queue-maxtotalcputime ))
+	   nordugrid-queue-maxtotalcputime $ nordugrid-queue-acl))
 
 #-----------------------------------------------------------------
 #attributes for the nordugrid-job objectclass


### PR DESCRIPTION
Previously advertisevo queue settings was ignored and all queues has
GlueCEAccessControlBaseRule based on advertisevo in cluster config section.

Now advertisevo for queue sections taken into account.