### PR TITLE
RTE SINGULARITY: Add a new parameter BINARY_PATH to redefine singularity location

### DIFF
--- a/src/services/a-rex/rte/ENV/SINGULARITY
+++ b/src/services/a-rex/rte/ENV/SINGULARITY
@@ -1,9 +1,11 @@
 # description: executes the job inside singularity container
 # param:SINGULARITY_IMAGE:string:NULL:singularity image or tree per VO, key:value comma separated, key default if VO not matched
 # param:SINGULARITY_OPTIONS:string: :singularity options
+# param:BINARY_PATH:string:/usr/bin/singularity:singularity binary location
 
 SINGULARITY_OPTIONS="${SINGULARITY_OPTIONS:-}"
 SINGULARITY_IMAGE="${SINGULARITY_IMAGE:-}"
+BINARY_PATH="${BINARY_PATH:-'/usr/bin/singularity'}"
 
 DEFAULT_IMAGE="NULL"
 
@@ -40,7 +42,7 @@ if [ "x$1" = "x0" ]; then
     echo $joboption_args |grep -q singularity; sused=$?
 
     if [ "x$IMAGE" != "xNULL" ] && [ "x$sused" == "x1" ] ; then
-       joboption_args="/usr/bin/singularity exec $SINGULARITY_OPTIONS --home \${RUNTIME_JOB_DIR} $IMAGE $joboption_args"
+       joboption_args="$BINARY_PATH exec $SINGULARITY_OPTIONS --home \${RUNTIME_JOB_DIR} $IMAGE $joboption_args"
        # account singularity image usage
        export ACCOUNTING_WN_INSTANCE="${IMAGE}"
     fi


### PR DESCRIPTION
Currently, the singularity executable path is hard coded as `/usr/bin/singularity`. 
Nevertheless, in some cases (on supercomputers for instance), the singularity executable can be defined in other locations.

This PR aims to add a new parameter to the Singularity RTE: `BINARY_PATH`, that would redefine the binary path when needed. The default, of course, would remain `/usr/bin/singularity`.
The parameter could be redefined either via the submission parameter, or via an environment variable.