### PR TITLE
Optimize the matching of pbs jobs to ARC jobs

### DIFF
--- a/src/services/a-rex/infoproviders/PBS.pm
+++ b/src/services/a-rex/infoproviders/PBS.pm
@@ -851,14 +851,21 @@ sub jobs_info ($$@) {
     };
 
     my ( %hoh_qstatf ) = read_qstat_f($path);
-    foreach my $pbsjid (keys %hoh_qstatf) {
+
+    # make two sorted indices
+    my @qstatkeys = sort keys %hoh_qstatf;
+    my @sjids = sort (@$jids);
+    my $jidindex = 0;
+
+    foreach my $pbsjid (@qstatkeys) {
         # only jobids known by A-REX are processed
         my $jid = undef;
-        foreach my $j (@$jids) {
-             if ( $pbsjid =~ /^$j$/ ) {
-                 $jid = $j;
-                 last;
-             }
+        while ($sjids[$jidindex] lt $pbsjid) {
+            last if ($jidindex == $#sjids);
+            $jidindex++;
+        }
+        if ( $pbsjid =~ /^$sjids[$jidindex]$/ ) {
+            $jid = $sjids[$jidindex];
         }
         next unless defined $jid;
         # handle qstat attributes of the jobs


### PR DESCRIPTION
The original nested loop with linear search was expensive;
by sorting the arrays beforehand only a single traversal
of both structures simultaneously is required.

Additional info in the writeup here: https://www.nikhef.nl/~dennisvd/arc-infosys-speedup/arc-infosys-speedup.html

This runs in production at Nikhef.
