### PR TITLE
Fix an infinite loop when the jids array is empty

### DIFF
--- a/src/services/a-rex/infoproviders/PBS.pm
+++ b/src/services/a-rex/infoproviders/PBS.pm
@@ -776,6 +776,9 @@ sub jobs_info ($$@) {
 
     my (%lrms_jobs);
 
+    # edge case if @$jids is empty, return now
+    return %lrms_jobs if ($#$jids < 0);
+
     # Fill %lrms_jobs here (da implementation)
 
     # rank is treated separately as it does not have an entry in


### PR DESCRIPTION
The jobs_info routine matches the known jobs with those in
the batch system, but commit 91d2e601f introduces a bug
where the index in the jids array assumes that there is at
least one job.

Since the routine should return an empty hash in case jids
is empty, get this done as soon as possible before doing
any other work.