### PR TITLE
Use 'info' from LogUtils

### DIFF
--- a/src/services/a-rex/infoproviders/PBS.pm
+++ b/src/services/a-rex/infoproviders/PBS.pm
@@ -22,7 +22,7 @@ our @EXPORT_OK = ('cluster_info',
       'users_info',
       'nodes_info');
 
-use LogUtils ( 'start_logging', 'error', 'warning', 'debug' );
+use LogUtils ( 'start_logging', 'error', 'warning', 'info', 'debug' );
 
 ##########################################
 # Saved private variables


### PR DESCRIPTION
Otherwise, call to info() (line 952) fails and the whole infosystem becomes unusable.